### PR TITLE
Fix VC Chat Close Button Spacing

### DIFF
--- a/src/components/redesign.css
+++ b/src/components/redesign.css
@@ -112,7 +112,7 @@
 
   /* only if update exists, move toolbar, there should be a better way to do this i think */
   .base_c48ade:has(.bar_c38106 > .trailing_c38106 > .button__85643) {
-    --custom-toolbar-icon-count: var(--custom-toolbar-icon-count) + 1;
+    --custom-toolbar-icon-count: 3;
   }
 
   /* placement of elements on left sidebar (servers/channels/panels) */


### PR DESCRIPTION
Resolves #11

- Update toolbar margin calculation to use an icon count variable.
- When toolbar appears in voice channel chat area, revert margin-right.