### PR TITLE
Fix sidebar hiding

### DIFF
--- a/src/components/redesign.css
+++ b/src/components/redesign.css
@@ -126,6 +126,10 @@
       "guilds sidebar"
       "guilds panels";
 
+    &.hidden_c48ade {
+      display: none;
+    }
+
     > .guilds_c48ade {
       grid-area: guilds;
       margin-bottom: 0;


### PR DESCRIPTION
Hidden class was being ignored on the sidebar. To replicate the bug, open any screenshare session then toggle fullscreen. You should see something like this:

<img width="1866" height="1440" alt="image" src="https://github.com/user-attachments/assets/9dbca679-aaed-4b4a-99e7-cd603517db6e" />

As you can see, the sidebar is still showing on the left when it shouldn't be, disrupting the viewing area of the stream. Also it's completely blank because it's meant to be hidden.

After fix:

<img width="1867" height="1440" alt="image" src="https://github.com/user-attachments/assets/9730872c-e2be-4c53-b557-86e408541026" />